### PR TITLE
User Story C3 R2

### DIFF
--- a/Client/src/model/ModelManager.java
+++ b/Client/src/model/ModelManager.java
@@ -168,15 +168,21 @@ public class ModelManager implements Model {
     public void setOpeningHours(String openingTime) {
         try {
             clientModel.setOpeningHours(openingTime);
+            checkLockedState();
         } catch (RemoteException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private void checkLockedState() {
+        setLockedState(!isOpen());
     }
 
     @Override
     public void setClosingHours(String closingTime) {
         try {
             clientModel.setClosingHours(closingTime);
+            checkLockedState();
         } catch (RemoteException e) {
             throw new RuntimeException(e);
         }

--- a/Client/src/view/controller/SettingsViewController.java
+++ b/Client/src/view/controller/SettingsViewController.java
@@ -136,8 +136,7 @@ public class SettingsViewController extends ViewController {
         dialog.setContentText("What do you want to edit?"); // <- preferences for the Choice Dialog
         Optional<String> result = dialog.showAndWait(); // show the dialog and wait for an answer
         if (result.isPresent()) {
-            boolean valid = false; // var to keep displaying the Text Input Dialog if the text from the text field is not valid
-            while ((result.get().equals("opening time") || result.get().equals("closing time")) && !valid) {
+            if ((result.get().equals("opening time") || result.get().equals("closing time"))) {
                 TextInputDialog timeDialog;
                 if (result.get().contains("open")) {
                     timeDialog = new TextInputDialog(viewModel.getOpeningHours()); // set the dialog default value according to the desired edit
@@ -158,7 +157,6 @@ public class SettingsViewController extends ViewController {
                             Logger.getInstance().log(LoggerType.DEBUG, "Closing time set to: " + timeResult.get());
                         }
                         Logger.getInstance().log(LoggerType.DEBUG, "Result time: " + timeResult.get());
-                        valid = true; // once the input was sent to the viewModel and no invalidation exception occurs, the dialog can exit
                     } catch (Exception e) {
                         Logger.getInstance().log(LoggerType.ERROR, "Illegal argument for " + result.get());
                     }

--- a/Client/src/view/controller/StartViewController.java
+++ b/Client/src/view/controller/StartViewController.java
@@ -1,5 +1,6 @@
 package view.controller;
 
+import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import logger.Logger;
 import logger.LoggerType;
@@ -7,8 +8,6 @@ import model.User;
 import view.View;
 import view.ViewController;
 import viewmodel.StartViewModel;
-import javafx.event.ActionEvent;
-import javafx.fxml.FXML;
 
 import java.rmi.RemoteException;
 import java.text.DateFormat;
@@ -23,13 +22,16 @@ import java.util.Optional;
 public class StartViewController extends ViewController {
     private StartViewModel viewModel;
     @FXML
+    public Label passwordLabel;
+    @FXML
     public Label titleLabel;
     @FXML
     private PasswordField passwordField;
     @FXML
     public Button mainButton;
 
-    public StartViewController() {}
+    public StartViewController() {
+    }
 
     @Override
     protected void init() {
@@ -58,11 +60,13 @@ public class StartViewController extends ViewController {
                 Logger.getInstance().log(LoggerType.DEBUG, "Store is locked, applying changes..");
                 titleLabel.setText("STORE LOCKED");
                 passwordField.visibleProperty().set(false);
+                passwordLabel.visibleProperty().set(false);
                 mainButton.setText("UNLOCK");
             } else {
                 Logger.getInstance().log(LoggerType.DEBUG, "Store is unlocked, applying changes..");
                 titleLabel.setText("STORE");
                 passwordField.visibleProperty().set(true);
+                passwordLabel.visibleProperty().set(true);
                 mainButton.setText("Login");
             }
         } catch (RemoteException e) {

--- a/Client/src/view/fxml/StartView.fxml
+++ b/Client/src/view/fxml/StartView.fxml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.PasswordField?>
 <?import javafx.scene.layout.*?>
-<?import javafx.scene.text.*?>
-
+<?import javafx.scene.text.Font?>
 <AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="view.controller.StartViewController">
    <VBox alignment="CENTER" prefHeight="400.0" prefWidth="600.0">
       <HBox alignment="TOP_CENTER" prefHeight="100.0" prefWidth="200.0">
@@ -14,7 +15,7 @@
          </Label>
       </HBox>
       <HBox alignment="CENTER" prefHeight="21.0" prefWidth="600.0">
-         <Label prefWidth="50.0" text="Password" />
+         <Label fx:id="passwordLabel" prefWidth="65.0" text="Password"/>
       </HBox>
       <HBox alignment="CENTER" prefHeight="13.0" prefWidth="600.0">
          <PasswordField fx:id="passwordField" onAction="#onMainButtonPressed" promptText="Enter password..." />

--- a/Client/src/viewmodel/SettingsViewModel.java
+++ b/Client/src/viewmodel/SettingsViewModel.java
@@ -41,9 +41,9 @@ public class SettingsViewModel implements SettingsViewModelInterface {
 
     @Override
     public void setLockedState(boolean b) {
+        model.setLockedState(b);
         if(b) {
             model.logout();
         }
-        model.setLockedState(b);
     }
 }


### PR DESCRIPTION
## Bug fixes dev release

> Thanks to @beniamincantorlabiserica for extensively testing the system and pointing these out.

C1:
- ADDED system now sets the store locked state accordingly after the user changes the working hours
- MODIFIED user can now cancel the 'working hours' dialog even if he started to modify them
- FIXED bug with the user not being automatically redirected to the starting screen after force locking the store if it just modified the working hours
- FIXED partially visible password label in the start view on some devices, now fully visible on all devices
- FIXED password label from the starting screen now hidden when the store is locked